### PR TITLE
chore: increase coverage threshold to 100%

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -15,7 +15,7 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@v4
-      - uses: synapse-sentinel/gate@main
+      - uses: synapse-sentinel/gate@master
         with:
           check: certify
           coverage-threshold: 100


### PR DESCRIPTION
## Summary
Align with Conduit ecosystem standard of 100% test coverage.

This PR will remain open until coverage reaches 100%. Once tests are added to cover all lines, Sentinel will auto-merge.

## Ecosystem Standard
All Conduit packages require:
- 100% test coverage
- Pest BDD syntax (describe/it)
- Security audit pass
- Auto-merge on certification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to use an updated action source and to enforce stricter automated test coverage requirements, raising the coverage threshold to ensure higher code quality in continuous integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->