### PR TITLE
feat: add pluggable authentication strategies

### DIFF
--- a/src/Auth/AuthenticationStrategy.php
+++ b/src/Auth/AuthenticationStrategy.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUi\GitHubConnector\Auth;
+
+use Saloon\Contracts\Authenticator;
+
+/**
+ * Contract for GitHub authentication strategies.
+ *
+ * Implement this interface to create custom authentication methods
+ * for the GitHub connector. Each strategy is responsible for providing
+ * a Saloon Authenticator that will be applied to requests.
+ */
+interface AuthenticationStrategy
+{
+    /**
+     * Get the Saloon authenticator for this strategy.
+     *
+     * The returned authenticator will be applied to all requests
+     * made through the connector.
+     */
+    public function getAuthenticator(): Authenticator;
+}

--- a/src/Auth/GitHubAppAuthentication.php
+++ b/src/Auth/GitHubAppAuthentication.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUi\GitHubConnector\Auth;
+
+use Saloon\Contracts\Authenticator;
+use Saloon\Http\Auth\TokenAuthenticator;
+
+/**
+ * GitHub App authentication strategy using JWT.
+ *
+ * This strategy is used for authenticating as a GitHub App.
+ * It accepts a pre-generated JWT token that should be created
+ * using the App's private key and App ID.
+ *
+ * Note: JWT generation is left to the consumer as it requires
+ * a JWT library. This strategy accepts the generated JWT directly.
+ *
+ * @example
+ * ```php
+ * // Generate JWT externally (using firebase/php-jwt or similar)
+ * $jwt = generateAppJwt($appId, $privateKey);
+ *
+ * $auth = new GitHubAppAuthentication($jwt);
+ * $connector = new Connector($auth);
+ * ```
+ *
+ * @see https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/about-authentication-with-a-github-app
+ */
+final class GitHubAppAuthentication implements AuthenticationStrategy
+{
+    /**
+     * Create a new GitHub App authentication strategy.
+     *
+     * @param  string  $jwt  Pre-generated JWT token for the GitHub App
+     */
+    public function __construct(
+        private readonly string $jwt
+    ) {}
+
+    /**
+     * Get the Saloon authenticator with Bearer prefix for JWT.
+     */
+    public function getAuthenticator(): Authenticator
+    {
+        return new TokenAuthenticator($this->jwt, 'Bearer');
+    }
+}

--- a/src/Auth/GitHubOAuth.php
+++ b/src/Auth/GitHubOAuth.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUi\GitHubConnector\Auth;
+
+use Saloon\Contracts\Authenticator;
+use Saloon\Http\Auth\TokenAuthenticator;
+
+/**
+ * OAuth access token authentication strategy for GitHub API.
+ *
+ * This strategy is used for authenticating with an OAuth access token
+ * obtained through the OAuth web flow or device flow.
+ *
+ * @example
+ * ```php
+ * // After completing OAuth flow and obtaining access token
+ * $auth = new GitHubOAuth($accessToken);
+ * $connector = new Connector($auth);
+ * ```
+ *
+ * @see https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
+ */
+final class GitHubOAuth implements AuthenticationStrategy
+{
+    /**
+     * Create a new OAuth authentication strategy.
+     *
+     * @param  string  $accessToken  OAuth access token from GitHub
+     */
+    public function __construct(
+        private readonly string $accessToken
+    ) {}
+
+    /**
+     * Get the Saloon authenticator with Bearer prefix for OAuth.
+     */
+    public function getAuthenticator(): Authenticator
+    {
+        return new TokenAuthenticator($this->accessToken, 'Bearer');
+    }
+}

--- a/src/Auth/TokenAuthentication.php
+++ b/src/Auth/TokenAuthentication.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUi\GitHubConnector\Auth;
+
+use Saloon\Contracts\Authenticator;
+use Saloon\Http\Auth\TokenAuthenticator;
+
+/**
+ * Token-based authentication strategy for GitHub API.
+ *
+ * This is the most common authentication method, using a GitHub
+ * Personal Access Token (PAT) or fine-grained token.
+ *
+ * @example
+ * ```php
+ * $auth = new TokenAuthentication('ghp_xxxxxxxxxxxx');
+ * $connector = new Connector($auth);
+ * ```
+ */
+final class TokenAuthentication implements AuthenticationStrategy
+{
+    /**
+     * Create a new token authentication strategy.
+     *
+     * @param  string  $token  GitHub personal access token or fine-grained token
+     */
+    public function __construct(
+        private readonly string $token
+    ) {}
+
+    /**
+     * Get the Saloon token authenticator.
+     */
+    public function getAuthenticator(): Authenticator
+    {
+        return new TokenAuthenticator($this->token);
+    }
+}

--- a/tests/Unit/Auth/GitHubAppAuthenticationTest.php
+++ b/tests/Unit/Auth/GitHubAppAuthenticationTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use ConduitUi\GitHubConnector\Auth\GitHubAppAuthentication;
+use Saloon\Http\Auth\TokenAuthenticator;
+
+it('can be instantiated with a JWT', function () {
+    $auth = new GitHubAppAuthentication('eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test');
+
+    expect($auth)->toBeInstanceOf(GitHubAppAuthentication::class);
+});
+
+it('returns a TokenAuthenticator with Bearer prefix', function () {
+    $jwt = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test';
+    $auth = new GitHubAppAuthentication($jwt);
+    $authenticator = $auth->getAuthenticator();
+
+    expect($authenticator)->toBeInstanceOf(TokenAuthenticator::class);
+});

--- a/tests/Unit/Auth/GitHubOAuthTest.php
+++ b/tests/Unit/Auth/GitHubOAuthTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use ConduitUi\GitHubConnector\Auth\GitHubOAuth;
+use Saloon\Http\Auth\TokenAuthenticator;
+
+it('can be instantiated with an access token', function () {
+    $auth = new GitHubOAuth('gho_access_token_here');
+
+    expect($auth)->toBeInstanceOf(GitHubOAuth::class);
+});
+
+it('returns a TokenAuthenticator with Bearer prefix', function () {
+    $accessToken = 'gho_access_token_here';
+    $auth = new GitHubOAuth($accessToken);
+    $authenticator = $auth->getAuthenticator();
+
+    expect($authenticator)->toBeInstanceOf(TokenAuthenticator::class);
+});

--- a/tests/Unit/Auth/TokenAuthenticationTest.php
+++ b/tests/Unit/Auth/TokenAuthenticationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use ConduitUi\GitHubConnector\Auth\TokenAuthentication;
+use Saloon\Http\Auth\TokenAuthenticator;
+
+it('can be instantiated with a token', function () {
+    $auth = new TokenAuthentication('ghp_test_token');
+
+    expect($auth)->toBeInstanceOf(TokenAuthentication::class);
+});
+
+it('returns a TokenAuthenticator', function () {
+    $auth = new TokenAuthentication('ghp_test_token');
+    $authenticator = $auth->getAuthenticator();
+
+    expect($authenticator)->toBeInstanceOf(TokenAuthenticator::class);
+});

--- a/tests/Unit/ConnectorAuthStrategyTest.php
+++ b/tests/Unit/ConnectorAuthStrategyTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use ConduitUi\GitHubConnector\Auth\GitHubAppAuthentication;
+use ConduitUi\GitHubConnector\Auth\GitHubOAuth;
+use ConduitUi\GitHubConnector\Auth\TokenAuthentication;
+use ConduitUi\GitHubConnector\Connector;
+use Saloon\Enums\Method;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\Request;
+
+it('can be instantiated with a TokenAuthentication strategy', function () {
+    $auth = new TokenAuthentication('ghp_test_token');
+    $connector = new Connector($auth);
+
+    expect($connector)->toBeInstanceOf(Connector::class);
+});
+
+it('can be instantiated with a GitHubAppAuthentication strategy', function () {
+    $auth = new GitHubAppAuthentication('jwt_token');
+    $connector = new Connector($auth);
+
+    expect($connector)->toBeInstanceOf(Connector::class);
+});
+
+it('can be instantiated with a GitHubOAuth strategy', function () {
+    $auth = new GitHubOAuth('gho_access_token');
+    $connector = new Connector($auth);
+
+    expect($connector)->toBeInstanceOf(Connector::class);
+});
+
+it('converts string token to TokenAuthentication for backward compatibility', function () {
+    $connector = new Connector('ghp_string_token');
+
+    expect($connector)->toBeInstanceOf(Connector::class);
+});
+
+it('can send requests with TokenAuthentication strategy', function () {
+    $auth = new TokenAuthentication('ghp_test_token');
+    $connector = new Connector($auth);
+
+    $mockClient = new MockClient([
+        MockResponse::make(['authenticated' => true], 200),
+    ]);
+
+    $connector->withMockClient($mockClient);
+
+    $request = new class extends Request
+    {
+        protected Method $method = Method::GET;
+
+        public function resolveEndpoint(): string
+        {
+            return '/user';
+        }
+    };
+
+    $response = $connector->send($request);
+
+    expect($response->json())->toBe(['authenticated' => true]);
+});
+
+it('can send requests with GitHubAppAuthentication strategy', function () {
+    $auth = new GitHubAppAuthentication('jwt_token');
+    $connector = new Connector($auth);
+
+    $mockClient = new MockClient([
+        MockResponse::make(['app' => 'authenticated'], 200),
+    ]);
+
+    $connector->withMockClient($mockClient);
+
+    $request = new class extends Request
+    {
+        protected Method $method = Method::GET;
+
+        public function resolveEndpoint(): string
+        {
+            return '/app';
+        }
+    };
+
+    $response = $connector->send($request);
+
+    expect($response->json())->toBe(['app' => 'authenticated']);
+});
+
+it('can send requests with GitHubOAuth strategy', function () {
+    $auth = new GitHubOAuth('gho_access_token');
+    $connector = new Connector($auth);
+
+    $mockClient = new MockClient([
+        MockResponse::make(['oauth' => 'authenticated'], 200),
+    ]);
+
+    $connector->withMockClient($mockClient);
+
+    $request = new class extends Request
+    {
+        protected Method $method = Method::GET;
+
+        public function resolveEndpoint(): string
+        {
+            return '/user';
+        }
+    };
+
+    $response = $connector->send($request);
+
+    expect($response->json())->toBe(['oauth' => 'authenticated']);
+});


### PR DESCRIPTION
- Add AuthenticationStrategy interface for injectable auth methods
- Implement TokenAuthentication for personal access tokens
- Implement GitHubAppAuthentication for GitHub App JWT authentication
- Implement GitHubOAuth for OAuth access tokens
- Update Connector to accept AuthenticationStrategy or string (backward compatible)
- Add comprehensive tests for all authentication strategies

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple GitHub authentication methods, including GitHub App authentication via JWT, OAuth access tokens, and personal access tokens.
  * Connector now accepts flexible authentication input while maintaining backward compatibility with string tokens.

* **Tests**
  * Added comprehensive unit tests for all authentication strategies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->