### PR TITLE
feat: add PHP 8.2+ type declarations to all exception classes

### DIFF
--- a/src/Exceptions/GitHubException.php
+++ b/src/Exceptions/GitHubException.php
@@ -1,33 +1,28 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUi\GitHubConnector\Exceptions;
 
 use Exception;
+use Saloon\Http\Response;
 
 /**
  * Base exception for all GitHub API errors.
  */
 class GitHubException extends Exception
 {
-    protected $response = null;
+    protected ?Response $response = null;
 
     protected ?array $githubError = null;
 
     protected ?string $recoverySuggestion = null;
 
-    /**
-     * Create a new GitHub exception.
-     *
-     * @param  string  $message  Exception message
-     * @param  mixed  $response  The HTTP response that caused the exception
-     * @param  int  $code  Exception code
-     * @param  Exception|null  $previous  Previous exception
-     */
     public function __construct(
         string $message = '',
-        $response = null,
+        ?Response $response = null,
         int $code = 0,
-        ?Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
 
@@ -38,10 +33,7 @@ class GitHubException extends Exception
         }
     }
 
-    /**
-     * Get the HTTP response that caused this exception.
-     */
-    public function getResponse()
+    public function getResponse(): ?Response
     {
         return $this->response;
     }
@@ -73,7 +65,7 @@ class GitHubException extends Exception
     /**
      * Parse GitHub error details from the response.
      */
-    protected function parseGitHubError($response): void
+    protected function parseGitHubError(Response $response): void
     {
         if (method_exists($response, 'json')) {
             $body = $response->json();

--- a/src/Exceptions/GitHubForbiddenException.php
+++ b/src/Exceptions/GitHubForbiddenException.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUi\GitHubConnector\Exceptions;
+
+use Saloon\Http\Response;
 
 /**
  * Exception thrown when access to a GitHub resource is forbidden.
@@ -9,9 +13,9 @@ class GitHubForbiddenException extends GitHubException
 {
     public function __construct(
         string $message = 'Access to GitHub resource is forbidden',
-        $response = null,
+        ?Response $response = null,
         int $code = 403,
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct($message, $response, $code, $previous);
 

--- a/src/Exceptions/GitHubRateLimitException.php
+++ b/src/Exceptions/GitHubRateLimitException.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUi\GitHubConnector\Exceptions;
+
+use Saloon\Http\Response;
 
 /**
  * Exception thrown when GitHub API rate limit is exceeded.
@@ -15,9 +19,9 @@ class GitHubRateLimitException extends GitHubException
 
     public function __construct(
         string $message = 'GitHub API rate limit exceeded',
-        $response = null,
+        ?Response $response = null,
         int $code = 403,
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct($message, $response, $code, $previous);
 
@@ -67,7 +71,7 @@ class GitHubRateLimitException extends GitHubException
     /**
      * Parse rate limit information from response headers.
      */
-    protected function parseRateLimitHeaders($response): void
+    protected function parseRateLimitHeaders(Response $response): void
     {
         if (method_exists($response, 'headers')) {
             $headers = $response->headers();

--- a/src/Exceptions/GitHubResourceNotFoundException.php
+++ b/src/Exceptions/GitHubResourceNotFoundException.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUi\GitHubConnector\Exceptions;
+
+use Saloon\Http\Response;
 
 /**
  * Exception thrown when a GitHub resource is not found.
@@ -9,9 +13,9 @@ class GitHubResourceNotFoundException extends GitHubException
 {
     public function __construct(
         string $message = 'GitHub resource not found',
-        $response = null,
+        ?Response $response = null,
         int $code = 404,
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct($message, $response, $code, $previous);
 

--- a/src/Exceptions/GitHubServerException.php
+++ b/src/Exceptions/GitHubServerException.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUi\GitHubConnector\Exceptions;
+
+use Saloon\Http\Response;
 
 /**
  * Exception thrown when GitHub API returns a server error.
@@ -9,9 +13,9 @@ class GitHubServerException extends GitHubException
 {
     public function __construct(
         string $message = 'GitHub API server error',
-        $response = null,
+        ?Response $response = null,
         int $code = 500,
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct($message, $response, $code, $previous);
 

--- a/src/Exceptions/GitHubValidationException.php
+++ b/src/Exceptions/GitHubValidationException.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUi\GitHubConnector\Exceptions;
+
+use Saloon\Http\Response;
 
 /**
  * Exception thrown when GitHub API validation fails.
@@ -11,9 +15,9 @@ class GitHubValidationException extends GitHubException
 
     public function __construct(
         string $message = 'GitHub API validation failed',
-        $response = null,
+        ?Response $response = null,
         int $code = 422,
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct($message, $response, $code, $previous);
 
@@ -37,7 +41,7 @@ class GitHubValidationException extends GitHubException
     /**
      * Parse validation errors from the GitHub response.
      */
-    protected function parseValidationErrors($response): void
+    protected function parseValidationErrors(Response $response): void
     {
         if (method_exists($response, 'json')) {
             $body = $response->json();

--- a/src/Exceptions/GithubAuthException.php
+++ b/src/Exceptions/GithubAuthException.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUi\GitHubConnector\Exceptions;
+
+use Saloon\Http\Response;
 
 /**
  * Exception thrown when GitHub authentication fails.
@@ -9,9 +13,9 @@ class GithubAuthException extends GitHubException
 {
     public function __construct(
         string $message = 'GitHub authentication failed',
-        $response = null,
+        ?Response $response = null,
         int $code = 401,
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct($message, $response, $code, $previous);
 


### PR DESCRIPTION
## Summary

- Add `declare(strict_types=1)` to the 7 exception files that were missing it
- Type `$response` property and all parameters as `?Response` (was untyped `mixed`)
- Use `\Throwable` for `$previous` constructor parameters (was `?\Exception`)
- Type protected method parameters (`parseGitHubError`, `parseValidationErrors`, `parseRateLimitHeaders`)

All 19 source files now have full PHP 8.2+ type declarations — strict types, typed properties, typed parameters, and return types.

## Test plan

- [x] All 85 existing tests pass
- [x] PHPStan level 4 passes with no errors
- [x] Pint code style passes

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Strengthened exception handler type definitions across the system for improved code reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->