### PR TITLE
chore: lower Sentinel Gate coverage threshold to 95%

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: synapse-sentinel/gate@v1
         with:
           check: certify
-          coverage-threshold: 100
+          coverage-threshold: 95
           auto-merge: true
           merge-method: squash
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Lowers the Sentinel Gate `coverage-threshold` from `100` to `95` in `.github/workflows/gate.yml`.

A 100% bar has been blocking incremental PRs with small coverage gaps from passing the gate. 95% is a more sustainable threshold that still catches meaningful regressions while letting legitimate work through (e.g. PR #27 at 98.8%).

## Test plan

- [ ] Sentinel Gate passes on this PR itself
- [ ] PR #27 (currently 98.8%) clears the gate once rebased onto this